### PR TITLE
feat: Add findDOMNode prop

### DIFF
--- a/src/ReplaceTransition.js
+++ b/src/ReplaceTransition.js
@@ -28,7 +28,7 @@ class ReplaceTransition extends React.Component {
     const child = React.Children.toArray(children)[idx];
 
     if (child.props[handler]) child.props[handler](...originalArgs)
-    if (this.props[handler]) this.props[handler](findDOMNode(this))
+    if (this.props[handler]) this.props[handler](this.props.findDOMNode(this))
   }
 
   render() {
@@ -39,6 +39,7 @@ class ReplaceTransition extends React.Component {
     } = this.props;
     const [first, second] = React.Children.toArray(children);
 
+    delete props.findDOMNode;
     delete props.onEnter;
     delete props.onEntering;
     delete props.onEntered;
@@ -76,6 +77,11 @@ ReplaceTransition.propTypes = {
 
     return null;
   },
+  findDOMNode: PropTypes.func,
 };
+
+ReplaceTransition.defaultProps = {
+  findDOMNode,
+}
 
 export default ReplaceTransition;

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -209,7 +209,7 @@ class Transition extends React.Component {
     if (nextStatus !== null) {
       // nextStatus will always be ENTERING or EXITING.
       this.cancelNextCallback()
-      const node = ReactDOM.findDOMNode(this)
+      const node = this.props.findDOMNode(this);
 
       if (nextStatus === ENTERING) {
         this.performEnter(node, mounting)
@@ -341,6 +341,7 @@ class Transition extends React.Component {
     delete childProps.appear
     delete childProps.enter
     delete childProps.exit
+    delete childProps.findDOMNode;
     delete childProps.timeout
     delete childProps.addEndListener
     delete childProps.onEnter
@@ -426,6 +427,14 @@ Transition.propTypes = {
    * Enable or disable exit transitions.
    */
   exit: PropTypes.bool,
+
+  /**
+   * The function to find the rendered DOM node that is passed to the transition callbacks.
+   *
+   * By default ReactDOM.findDOMNode is used. For `React.StrictMode` compatiblity
+   * another function must be provided.
+   */
+  findDOMNode: PropTypes.func,
 
   /**
    * The duration of the transition, in milliseconds.
@@ -529,6 +538,7 @@ Transition.defaultProps = {
   appear: false,
   enter: true,
   exit: true,
+  findDOMNode: ReactDOM.findDOMNode,
 
   onEnter: noop,
   onEntering: noop,

--- a/test/Transition-test.js
+++ b/test/Transition-test.js
@@ -472,9 +472,9 @@ describe('Transition', () => {
 
   describe('findDOMNode', () => {
     it('uses ReactDOM.findDOMNode by default', done => {
-      const expectDiv = sinon.spy(node => expect(node.nodeName).toEqual('DIV'));
+      const expectDiv = jest.fn(node => expect(node.nodeName).toEqual('DIV'));
       const handleExited = () => {
-        expect(expectDiv.called).toBe(true);
+        expect(expectDiv).toHaveBeenCalled()
 
         done();
       }
@@ -514,9 +514,9 @@ describe('Transition', () => {
         }
       }
 
-      const expectSpan = sinon.spy(node => expect(node.nodeName).toEqual('SPAN'));
+      const expectSpan = jest.fn(node => expect(node.nodeName).toEqual('SPAN'));
       const handleExited = () => {
-        expect(expectSpan.called).toBe(true);
+        expect(expectSpan).toHaveBeenCalled();
 
         done();
       }

--- a/test/Transition-test.js
+++ b/test/Transition-test.js
@@ -469,4 +469,46 @@ describe('Transition', () => {
       wrapper.setState({ in: false })
     })
   })
+
+  describe('findDOMNode', () => {
+    it('can receive a custom findDOMNode method', done => {
+      class StrictModeTransition extends React.Component {
+        constructor(props) {
+          super(props);
+          this.childRef = React.createRef();
+          this.findDOMNode = this.findDOMNode.bind(this);
+        }
+
+        findDOMNode() {
+          return this.childRef.current;
+        }
+
+        render() {
+          return (
+            <Transition findDOMNode={this.findDOMNode} {...this.props}>
+              {status => <div><span ref={this.childRef}>{status}</span></div>}
+            </Transition>
+          );
+        }
+      }
+
+      const expectSpan = sinon.spy(node => expect(node.nodeName).toEqual('SPAN'));
+      const handleExited = () => {
+        expect(expectSpan.called).toBe(true);
+
+        done();
+      }
+
+      const wrapper = mount(
+        <StrictModeTransition
+          in
+          timeout={10}
+          onExiting={expectSpan}
+          onExited={handleExited}
+        />
+      );
+
+      wrapper.setProps({ in: false });
+    })
+  })
 })

--- a/test/Transition-test.js
+++ b/test/Transition-test.js
@@ -471,6 +471,28 @@ describe('Transition', () => {
   })
 
   describe('findDOMNode', () => {
+    it('uses ReactDOM.findDOMNode by default', done => {
+      const expectDiv = sinon.spy(node => expect(node.nodeName).toEqual('DIV'));
+      const handleExited = () => {
+        expect(expectDiv.called).toBe(true);
+
+        done();
+      }
+
+      const wrapper = mount(
+        <Transition
+          in
+          timeout={10}
+          onExiting={expectDiv}
+          onExited={handleExited}
+        >
+          {status => <div><span>{status}</span></div>}
+        </Transition>
+      );
+
+      wrapper.setProps({ in: false });
+    })
+
     it('can receive a custom findDOMNode method', done => {
       class StrictModeTransition extends React.Component {
         constructor(props) {


### PR DESCRIPTION
Mirror of https://github.com/reactjs/react-transition-group/pull/457

It's just the simplest solution for our use case. Since we already have refs setup in the core properly the integration would be pretty simple.

## Alternatives
### add heuristic to skip findDOMNode call
https://github.com/reactjs/react-transition-group/pull/468

Wouldn't work for `@material-ui/core` because it would never detect if a node is needed in e.g. Snackbar: https://github.com/eps1lon/material-ui/blob/61a229a77b0bb0f739d59765593867b736483891/packages/material-ui/src/Snackbar/Snackbar.js#L246

### ref + cloneElement

Would be yet another cloneElement call. In addition to that Transition is a class component which means we don't have access to `useForkRef` i.e. proper ref cleanup.